### PR TITLE
fix - Allow Phone Payments to Update Payment Request Status #247

### DIFF
--- a/webshop/webshop/doctype/override_doctype/payment_request.py
+++ b/webshop/webshop/doctype/override_doctype/payment_request.py
@@ -20,9 +20,6 @@ class PaymentRequest(OriginalPaymentRequest):
         if frappe.local.session.user == "Guest":
             return
 
-        if self.payment_channel == "Phone":
-            return
-
         cart_settings = frappe.get_doc("Webshop Settings")
 
         if not cart_settings.enabled:


### PR DESCRIPTION
This change allows phone payments (e.g., M-Pesa) to update the status of a **Payment Request** once the payment is complete.

### Change Details:
       `if self.payment_channel == "Phone":
        return` 
-   This logic previously prevented phone payments from progressing, causing issues in scenarios like M-Pesa payments where the status needs to be updated automatically.

### Impact:

-   Ensures smoother integration with M-Pesa and other phone-based payment systems.
-   Payment Requests will now correctly reflect their status for phone payments once payment completion is detected.